### PR TITLE
Changed single quote for double quote

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Initial implementation includes JSON views powered by Groovy's JsonBuilder, howe
 
 Add the following dependency to the `dependencies` block of your `build.gradle`:
 
-    compile "org.grails.plugins:views-json:1.0.0.M1'
+    compile "org.grails.plugins:views-json:1.0.0.M1"
 
 To enable Gradle compilation of JSON views for production environment add the following to the `buildscript` `dependencies` block:
 


### PR DESCRIPTION
Hi Graeme, I just changed single quota for double quota in order to avoid compile to fail. Here the message

grails compile
FAILURE: Build failed with an exception.

* Where:
Build file '/home/a123/apps/g306/build.gradle' line: 74

* What went wrong:
Could not compile build file '/home/a123/apps/g306/build.gradle'.
> startup failed:
  build file '/home/a123/apps/g306/build.gradle': 74: expecting anything but ''\n''; got it anyway @ line 74, column 51.
     s.plugins:views-json:1.0.0.M1'
                                   ^
  
  1 error


* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output.

BUILD FAILED

Total time: 0.895 secs
