### PR TITLE
Added namespace support

### DIFF
--- a/core/src/main/groovy/grails/views/ViewUriResolver.groovy
+++ b/core/src/main/groovy/grails/views/ViewUriResolver.groovy
@@ -17,4 +17,16 @@ interface ViewUriResolver {
      * @return The template URI
      */
     String resolveTemplateUri(String controllerName, String templateName)
+
+    /**
+     * Resolves a template URI for the given path
+     *
+     * Example: assert resolveTemplateUri('api', 'foo', 'bar') == /api/foo/_bar.gson
+     *
+     * @param controllerNamespace The controller controllerNamespace
+     * @param controllerName The controller name
+     * @param path The path to the template
+     * @return The template URI
+     */
+    String resolveTemplateUri(String controllerNamespace, String controllerName, String templateName)
 }

--- a/core/src/main/groovy/grails/views/api/GrailsView.groovy
+++ b/core/src/main/groovy/grails/views/api/GrailsView.groovy
@@ -74,6 +74,10 @@ trait GrailsView extends HttpView implements WriterProvider, WritableScript {
     }
 
     /**
+     * @return The current controller namespace
+     */
+    String controllerNamespace
+    /**
      * @return The current controller name
      */
     String controllerName

--- a/core/src/main/groovy/grails/views/mvc/GenericGroovyTemplateView.groovy
+++ b/core/src/main/groovy/grails/views/mvc/GenericGroovyTemplateView.groovy
@@ -91,6 +91,9 @@ class GenericGroovyTemplateView extends AbstractUrlBasedView {
                 grailsView.setControllerName(
                         webRequest.controllerName
                 )
+                grailsView.setControllerNamespace(
+                        webRequest.controllerNamespace
+                )
             }
         }
         if (writable instanceof HttpView) {

--- a/core/src/main/groovy/grails/views/mvc/renderer/DefaultViewRenderer.groovy
+++ b/core/src/main/groovy/grails/views/mvc/renderer/DefaultViewRenderer.groovy
@@ -67,6 +67,9 @@ abstract class DefaultViewRenderer<T> extends DefaultHtmlRenderer<T> {
 
         String viewUri = "/${context.controllerName}/${viewName}"
         def webRequest = ((ServletRenderContext) context).getWebRequest()
+        if (webRequest.controllerNamespace) {
+            viewUri = "/${webRequest.controllerNamespace}" + viewUri
+        }
 
         def request = webRequest.currentRequest
         def response = webRequest.currentResponse

--- a/core/src/main/groovy/grails/views/resolve/GenericViewUriResolver.groovy
+++ b/core/src/main/groovy/grails/views/resolve/GenericViewUriResolver.groovy
@@ -24,6 +24,10 @@ class GenericViewUriResolver implements ViewUriResolver {
     }
 
     String resolveTemplateUri(String controllerName, String templateName, boolean includeExtension = true) {
+        return resolveTemplateUri(null, controllerName, templateName, includeExtension)
+    }
+
+    String resolveTemplateUri(String controllerNamespace, String controllerName, String templateName, boolean includeExtension = true) {
         if (templateName.startsWith(SLASH_STR)) {
             return getAbsoluteTemplateURI(templateName, includeExtension)
         }
@@ -35,6 +39,9 @@ class GenericViewUriResolver implements ViewUriResolver {
         if (lastSlash > -1) {
             pathToTemplate = templateName.substring(0, lastSlash + 1)
             templateName = templateName.substring(lastSlash + 1)
+        }
+        if(controllerNamespace != null) {
+            buf << SLASH << controllerNamespace
         }
         if(controllerName != null) {
             buf << SLASH << controllerName

--- a/functional-tests/grails-app/controllers/UrlMappings.groovy
+++ b/functional-tests/grails-app/controllers/UrlMappings.groovy
@@ -17,5 +17,6 @@ class UrlMappings {
         "/teams/deep/$id"(controller: "team", action:"deep")
         "/teams/hal/$id"(controller: "team", action:"hal")
         "/authors"(resources:"author")
+        "/api/book/$action?"(controller: 'book', namespace: 'api')
     }
 }

--- a/functional-tests/grails-app/controllers/functional/tests/api/BookController.groovy
+++ b/functional-tests/grails-app/controllers/functional/tests/api/BookController.groovy
@@ -1,0 +1,15 @@
+package functional.tests.api
+
+import functional.tests.Book
+
+
+class BookController {
+
+    static namespace = 'api'
+
+    static responseFormats = ['json']
+
+    def index() {
+        respond new Book(title: 'API - The Shining')
+    }
+}

--- a/functional-tests/grails-app/controllers/functional/tests/api/BookController.groovy
+++ b/functional-tests/grails-app/controllers/functional/tests/api/BookController.groovy
@@ -12,4 +12,8 @@ class BookController {
     def index() {
         respond new Book(title: 'API - The Shining')
     }
+
+    def nested() {
+        respond new Book(title: 'API - The Shining')
+    }
 }

--- a/functional-tests/grails-app/views/api/book/_foo.gson
+++ b/functional-tests/grails-app/views/api/book/_foo.gson
@@ -1,0 +1,3 @@
+json {
+    foo 'bar'
+}

--- a/functional-tests/grails-app/views/api/book/index.gson
+++ b/functional-tests/grails-app/views/api/book/index.gson
@@ -1,0 +1,9 @@
+package api.book
+
+model {
+    functional.tests.Book book
+}
+json {
+    api 'version 1.0 (Namespaced)'
+    title book.title
+}

--- a/functional-tests/grails-app/views/api/book/nested.gson
+++ b/functional-tests/grails-app/views/api/book/nested.gson
@@ -1,0 +1,3 @@
+package api.book
+
+json g.render(template: 'foo')

--- a/functional-tests/src/integration-test/groovy/functional/tests/api/NamespacedBookSpec.groovy
+++ b/functional-tests/src/integration-test/groovy/functional/tests/api/NamespacedBookSpec.groovy
@@ -24,4 +24,17 @@ class NamespacedBookSpec extends GebSpec {
             resp.json.api == "version 1.0 (Namespaced)"
             resp.json.title == "API - The Shining"
     }
+
+    void "test nested template rendering with a namespace"() {
+        given: "A rest client"
+            def builder = new RestBuilder()
+
+        when: "A request is sent to a controller with a namespace"
+            RestResponse resp = builder.get("$baseUrl/api/book/nested")
+
+        then: "The response contains the child template"
+            resp.status == 200
+            resp.headers.getFirst(HttpHeaders.CONTENT_TYPE) == 'application/json;charset=UTF-8'
+            resp.json.foo == "bar"
+    }
 }

--- a/functional-tests/src/integration-test/groovy/functional/tests/api/NamespacedBookSpec.groovy
+++ b/functional-tests/src/integration-test/groovy/functional/tests/api/NamespacedBookSpec.groovy
@@ -1,0 +1,27 @@
+package functional.tests.api
+
+import geb.spock.GebSpec
+import grails.plugins.rest.client.RestBuilder
+import grails.plugins.rest.client.RestResponse
+import grails.test.mixin.integration.Integration
+import grails.transaction.Rollback
+import grails.web.http.HttpHeaders
+
+@Integration
+@Rollback
+class NamespacedBookSpec extends GebSpec {
+
+    void "test view rendering with a namespace"() {
+        given: "A rest client"
+            def builder = new RestBuilder()
+
+        when: "A request is sent to a controller with a namespace"
+            RestResponse resp = builder.get("$baseUrl/api/book")
+
+        then: "The response is correct"
+            resp.status == 200
+            resp.headers.getFirst(HttpHeaders.CONTENT_TYPE) == 'application/json;charset=UTF-8'
+            resp.json.api == "version 1.0 (Namespaced)"
+            resp.json.title == "API - The Shining"
+    }
+}

--- a/json/src/main/groovy/grails/plugin/json/renderer/AbstractJsonViewContainerRenderer.groovy
+++ b/json/src/main/groovy/grails/plugin/json/renderer/AbstractJsonViewContainerRenderer.groovy
@@ -30,6 +30,10 @@ abstract class AbstractJsonViewContainerRenderer<C,T> extends DefaultJsonRendere
     void render(T object, RenderContext context) {
         if(jsonViewResolver != null) {
             String viewUri = "/${context.controllerName}/_${GrailsNameUtils.getPropertyName(targetType)}"
+            def webRequest = ((ServletRenderContext) context).getWebRequest()
+            if (webRequest.controllerNamespace) {
+                viewUri = "/${webRequest.controllerNamespace}" + viewUri
+            }
             def view = jsonViewResolver.resolveView(viewUri, context.locale)
             if(view == null) {
                 view = jsonViewResolver.resolveView(targetType, context.locale)
@@ -42,7 +46,6 @@ abstract class AbstractJsonViewContainerRenderer<C,T> extends DefaultJsonRendere
                 if(contextModel instanceof Map) {
                     model.putAll((Map)contextModel)
                 }
-                def webRequest = ((ServletRenderContext) context).getWebRequest()
 
                 def request = webRequest.currentRequest
                 def response = webRequest.currentResponse

--- a/json/src/main/groovy/grails/plugin/json/view/api/internal/DefaultGrailsJsonViewHelper.groovy
+++ b/json/src/main/groovy/grails/plugin/json/view/api/internal/DefaultGrailsJsonViewHelper.groovy
@@ -502,7 +502,7 @@ class DefaultGrailsJsonViewHelper extends DefaultGrailsViewHelper implements Gra
             def var = arguments.var ?: 'it'
             def templateUri = templateEngine
                     .viewUriResolver
-                    .resolveTemplateUri(view.getControllerName(), template.toString())
+                    .resolveTemplateUri(view.getControllerNamespace(), view.getControllerName(), template.toString())
             def childTemplate = templateEngine.resolveTemplate(templateUri, view.locale)
             if(childTemplate != null) {
                 FastStringWriter stringWriter = new FastStringWriter()

--- a/json/src/main/groovy/grails/plugin/json/view/api/internal/DefaultGrailsJsonViewHelper.groovy
+++ b/json/src/main/groovy/grails/plugin/json/view/api/internal/DefaultGrailsJsonViewHelper.groovy
@@ -548,6 +548,7 @@ class DefaultGrailsJsonViewHelper extends DefaultGrailsViewHelper implements Gra
         writable.locale = view.locale
         writable.response = view.response
         writable.request = view.request
+        writable.controllerNamespace = view.controllerNamespace
         writable.controllerName = view.controllerName
         writable.actionName = view.actionName
         return writable

--- a/json/src/main/groovy/grails/plugin/json/view/test/TestRequestConfigurer.groovy
+++ b/json/src/main/groovy/grails/plugin/json/view/test/TestRequestConfigurer.groovy
@@ -43,6 +43,10 @@ class TestRequestConfigurer implements Request {
         jsonView.setControllerName(controllerName)
     }
 
+    void setControllerNamespace(String controllerNamespace) {
+        jsonView.setControllerNamespace(controllerNamespace)
+    }
+
 
     TestRequestConfigurer actionName(String actionName) {
         this.actionName = actionName
@@ -51,6 +55,11 @@ class TestRequestConfigurer implements Request {
 
     TestRequestConfigurer controllerName(String controllerName) {
         this.controllerName = controllerName
+        return this
+    }
+
+    TestRequestConfigurer controllerNamespace(String controllerNamespace) {
+        this.controllerNamespace = controllerNamespace
         return this
     }
 

--- a/json/src/test/groovy/grails/plugin/json/view/GenericViewUriResolverSpec.groovy
+++ b/json/src/test/groovy/grails/plugin/json/view/GenericViewUriResolverSpec.groovy
@@ -15,4 +15,12 @@ class GenericViewUriResolverSpec extends Specification{
         expect:
             resolver.resolveTemplateUri("foo", "bar") == '/foo/_bar.gson'
     }
+
+    void "test resolve template URIs with a namespace"() {
+        given:
+            def resolver = new GenericViewUriResolver(".gson")
+
+        expect:
+            resolver.resolveTemplateUri("namespace", "foo", "bar") == '/namespace/foo/_bar.gson'
+    }
 }

--- a/markup/src/main/resources/gml.gdsl
+++ b/markup/src/main/resources/gml.gdsl
@@ -7,6 +7,7 @@ contributor([gdslScriptContext]) {
     property name: "g", type: "grails.views.api.GrailsViewHelper"
     property name: "mappingContext", type: "org.grails.datastore.mapping.model.MappingContext"
     property name: "messageSource", type: "org.springframework.context.MessageSource"
+    property name: "controllerNamespace", type: "java.lang.String"
     property name: "controllerName", type: "java.lang.String"
     property name: "actionName", type: "java.lang.String"
     property name: "templateEngine", type: "grails.plugin.markup.view.MarkupViewTemplateEngine"


### PR DESCRIPTION
The namespace is now taken into consideration when resolving views & templates.
The `controllerNamespace` is added to `GrailsView`.  GroovyDSL files and the `TestRequestConfigurer` have been updated to support namespaces.