### PR TITLE
Allow absolute view names to be used, e.g. with respond's 'view' parameter

### DIFF
--- a/core/src/main/groovy/grails/views/mvc/renderer/DefaultViewRenderer.groovy
+++ b/core/src/main/groovy/grails/views/mvc/renderer/DefaultViewRenderer.groovy
@@ -65,7 +65,13 @@ abstract class DefaultViewRenderer<T> extends DefaultHtmlRenderer<T> {
             viewName = context.actionName
         }
 
-        String viewUri = "/${context.controllerName}/${viewName}"
+        String viewUri
+        if (viewName?.startsWith('/')) {
+            viewUri = viewName
+        } else {
+           viewUri = "/${context.controllerName}/${viewName}"
+        }
+
         def webRequest = ((ServletRenderContext) context).getWebRequest()
         if (webRequest.controllerNamespace) {
             viewUri = "/${webRequest.controllerNamespace}" + viewUri

--- a/functional-tests/grails-app/controllers/UrlMappings.groovy
+++ b/functional-tests/grails-app/controllers/UrlMappings.groovy
@@ -13,6 +13,7 @@ class UrlMappings {
 
         "/books"(resources:"book")
         "/books/listExcludes"(controller: "book", action: "listExcludes")
+        "/books/non-standard-template"(controller:"book", action:"nonStandardTemplate")
         "/teams"(resources:"team")
         "/products"(resources:"product")
         "/teams/deep/$id"(controller: "team", action:"deep")

--- a/functional-tests/grails-app/controllers/functional/tests/BookController.groovy
+++ b/functional-tests/grails-app/controllers/functional/tests/BookController.groovy
@@ -13,4 +13,8 @@ class BookController extends RestfulController<Book> {
     def listExcludes() {
         [books: listAllResources(params)]
     }
+
+    def nonStandardTemplate() {
+        respond new Book(title: 'template found'), view:'/non-standard/template'
+    }
 }

--- a/functional-tests/grails-app/views/non-standard/template.gson
+++ b/functional-tests/grails-app/views/non-standard/template.gson
@@ -1,0 +1,7 @@
+model {
+    Book book
+}
+
+json {
+    bookTitle book.title
+}

--- a/functional-tests/src/integration-test/groovy/functional/tests/BookSpec.groovy
+++ b/functional-tests/src/integration-test/groovy/functional/tests/BookSpec.groovy
@@ -103,4 +103,19 @@ class BookSpec extends GebSpec {
         resp.headers.getFirst(HttpHeaders.CONTENT_TYPE) == 'application/json;charset=UTF-8'
         resp.text == '[{"id":1,"timeZone":"America/New_York","vendor":"ConfigVendor","fromParams":3}]'
     }
+
+    void "View parameter passed to the render method can be used for non-standard view locations"() {
+        given:"A rest client"
+        def builder = new RestBuilder()
+
+        when:"A GET is issued to a request with a template at a non-standard location"
+
+        def resp = builder.get("$baseUrl/books/non-standard-template")
+
+        then:"The template was rendered successfully"
+        resp.status == 200
+        resp.headers.getFirst(HttpHeaders.CONTENT_TYPE) == 'application/json;charset=UTF-8'
+        resp.text == '{"bookTitle":"template found"}'
+
+    }
 }


### PR DESCRIPTION
This pull request enables using non-standard view locations by providing absolute paths, similar to how GSP views are selected, by using the existing `respond` method's `view` parameter:

    respond book, view: '/non-standard-location/book'

We came across this use case in a project of ours where we maintain several APIs, split into public/internal and configuration/operational categories. Our view directory structure follows a non-standard convention with actions from the same controller sometimes serving views from different directories (which rules out namespaces, besides we've had other problems with those). The system works for GSP views but not for the GSON ones.

One thing this pull request does not address is rendering templates from within `gson` files - absolute paths must currently be used, I'm not sure how big of a problem this is and how easy it would be to fix?