### PR TITLE
Include parameters when rendering a template from a view

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,10 @@ cache:
 jdk:
 - openjdk7
 script: ./travis-build.sh
+addons:
+  hosts:
+    - grails-views
+  hostname: grails-views
 env:
   global:
   - GIT_NAME="Graeme Rocher"

--- a/functional-tests/grails-app/controllers/UrlMappings.groovy
+++ b/functional-tests/grails-app/controllers/UrlMappings.groovy
@@ -17,6 +17,7 @@ class UrlMappings {
         "/books/listCallsTmpl"(controller: "book", action: "listCallsTmpl")
         "/books/listCallsTmplVar"(controller: "book", action: "listCallsTmplVar")
         "/books/listCallsTmplExtraData"(controller: "book", action: "listCallsTmplExtraData")
+        "/books/showWithParams/$id"(controller: "book", action: "showWithParams")
         "/books/non-standard-template"(controller:"book", action:"nonStandardTemplate")
         "/teams"(resources:"team")
         "/products"(resources:"product")

--- a/functional-tests/grails-app/controllers/functional/tests/BookController.groovy
+++ b/functional-tests/grails-app/controllers/functional/tests/BookController.groovy
@@ -34,4 +34,8 @@ class BookController extends RestfulController<Book> {
     def nonStandardTemplate() {
         respond([book: new Book(title: 'template found'), custom: new CustomClass(name: "Sally")], view:'/non-standard/template')
     }
+
+    def showWithParams() {
+        show()
+    }
 }

--- a/functional-tests/grails-app/views/book/_bookWithParams.gson
+++ b/functional-tests/grails-app/views/book/_bookWithParams.gson
@@ -1,0 +1,9 @@
+import functional.tests.Book
+
+model {
+    Book book
+}
+
+json g.render(book) {
+    paramsFromTemplate params
+}

--- a/functional-tests/grails-app/views/book/showWithParams.gson
+++ b/functional-tests/grails-app/views/book/showWithParams.gson
@@ -1,0 +1,10 @@
+import functional.tests.Book
+
+model {
+    Book book
+}
+
+json {
+    paramsFromView params
+    book tmpl.'/book/bookWithParams'(book)
+}

--- a/functional-tests/src/integration-test/groovy/functional/tests/BookSpec.groovy
+++ b/functional-tests/src/integration-test/groovy/functional/tests/BookSpec.groovy
@@ -110,6 +110,15 @@ class BookSpec extends GebSpec {
         resp.status == 200
         resp.headers.getFirst(HttpHeaders.CONTENT_TYPE) == 'application/json;charset=UTF-8'
         resp.text == '[{"id":1,"timeZone":"America/New_York","vendor":"ConfigVendor","fromParams":4}]'
+
+        when:"A GET is issued for a specific book rendered by a template"
+        resp = builder.get("${baseUrl}books/showWithParams/1?expand=foo")
+
+        then:"view rendering with template passes parameters"
+        resp.status == 200
+        resp.headers.getFirst(HttpHeaders.CONTENT_TYPE) == 'application/json;charset=UTF-8'
+        resp.json.paramsFromView == resp.json.book.paramsFromTemplate
+
     }
 
     void "View parameter passed to the render method can be used for non-standard view locations"() {

--- a/json/src/main/groovy/grails/plugin/json/view/api/internal/DefaultGrailsJsonViewHelper.groovy
+++ b/json/src/main/groovy/grails/plugin/json/view/api/internal/DefaultGrailsJsonViewHelper.groovy
@@ -819,6 +819,7 @@ class DefaultGrailsJsonViewHelper extends DefaultJsonViewHelper implements Grail
         writable.locale = view.locale
         writable.response = view.response
         writable.request = view.request
+        writable.params = view.params
         writable.controllerNamespace = view.controllerNamespace
         writable.controllerName = view.controllerName
         writable.actionName = view.actionName


### PR DESCRIPTION
Fixes https://github.com/grails/grails-views/issues/138.

The request/response fields are already passed down to the template rendered from the view. This PR simply does the same to the params field.