### PR TITLE
Fix rendering view outside of namespace as fallback

### DIFF
--- a/core/src/main/groovy/grails/views/mvc/renderer/DefaultViewRenderer.groovy
+++ b/core/src/main/groovy/grails/views/mvc/renderer/DefaultViewRenderer.groovy
@@ -79,11 +79,13 @@ abstract class DefaultViewRenderer<T> extends DefaultHtmlRenderer<T> {
         AbstractUrlBasedView view
         String namespace = webRequest.controllerNamespace
         if (namespace) {
-            view = (AbstractUrlBasedView)viewResolver.resolveView("${namespace}/${viewUri}", request, response)
+            view = (AbstractUrlBasedView)viewResolver.resolveView("/${namespace}${viewUri}", request, response)
 
             if (view == null) {
                 view = (AbstractUrlBasedView)viewResolver.resolveView(viewUri, request, response)
             }
+        } else {
+            view = (AbstractUrlBasedView)viewResolver.resolveView(viewUri, request, response)
         }
 
         if(view == null) {

--- a/core/src/main/groovy/grails/views/mvc/renderer/DefaultViewRenderer.groovy
+++ b/core/src/main/groovy/grails/views/mvc/renderer/DefaultViewRenderer.groovy
@@ -80,11 +80,9 @@ abstract class DefaultViewRenderer<T> extends DefaultHtmlRenderer<T> {
         String namespace = webRequest.controllerNamespace
         if (namespace) {
             view = (AbstractUrlBasedView)viewResolver.resolveView("/${namespace}${viewUri}", request, response)
-
-            if (view == null) {
-                view = (AbstractUrlBasedView)viewResolver.resolveView(viewUri, request, response)
-            }
-        } else {
+        }
+        
+        if (view == null) {
             view = (AbstractUrlBasedView)viewResolver.resolveView(viewUri, request, response)
         }
 

--- a/core/src/main/groovy/grails/views/mvc/renderer/DefaultViewRenderer.groovy
+++ b/core/src/main/groovy/grails/views/mvc/renderer/DefaultViewRenderer.groovy
@@ -73,14 +73,19 @@ abstract class DefaultViewRenderer<T> extends DefaultHtmlRenderer<T> {
         }
 
         def webRequest = ((ServletRenderContext) context).getWebRequest()
-        if (webRequest.controllerNamespace) {
-            viewUri = "/${webRequest.controllerNamespace}" + viewUri
-        }
-
         def request = webRequest.currentRequest
         def response = webRequest.currentResponse
 
-        AbstractUrlBasedView view = (AbstractUrlBasedView)viewResolver.resolveView(viewUri, request, response)
+        AbstractUrlBasedView view
+        String namespace = webRequest.controllerNamespace
+        if (namespace) {
+            view = (AbstractUrlBasedView)viewResolver.resolveView("${namespace}/${viewUri}", request, response)
+
+            if (view == null) {
+                view = (AbstractUrlBasedView)viewResolver.resolveView(viewUri, request, response)
+            }
+        }
+
         if(view == null) {
             if(proxyHandler != null) {
                 object = (T)proxyHandler.unwrapIfProxy(object)

--- a/functional-tests/grails-app/controllers/functional/tests/api/BookController.groovy
+++ b/functional-tests/grails-app/controllers/functional/tests/api/BookController.groovy
@@ -24,4 +24,8 @@ class BookController {
     def testRespond() {
         respond(new Book(title: 'API - The Shining'), view: 'index')
     }
+
+    def testRespondOutsideNamespace() {
+        respond(new Book(title: 'API - The Shining'), view: 'indexOutsideNamespace')
+    }
 }

--- a/functional-tests/grails-app/views/book/indexOutsideNamespace.gson
+++ b/functional-tests/grails-app/views/book/indexOutsideNamespace.gson
@@ -1,0 +1,9 @@
+import functional.tests.Book
+
+model {
+    Book book
+}
+json {
+    api 'version 1.0 (Non-Namespaced)'
+    title book.title
+}

--- a/functional-tests/src/integration-test/groovy/functional/tests/api/NamespacedBookSpec.groovy
+++ b/functional-tests/src/integration-test/groovy/functional/tests/api/NamespacedBookSpec.groovy
@@ -100,4 +100,18 @@ class NamespacedBookSpec extends GebSpec {
         resp.json.api == "version 1.0 (Namespaced)"
         resp.json.title == "API - The Shining"
     }
+
+    void "test respond(foo, view: ..) in controllers with namespaces works, view outside of namespace"() {
+        given: "A rest client"
+        def builder = new RestBuilder()
+
+        when: "A request is sent to a controller with a namespace"
+        RestResponse resp = builder.get("${baseUrl}api/book/testRespondOutsideNamespace")
+
+        then: "The response is correct"
+        resp.status == 200
+        resp.headers.getFirst(HttpHeaders.CONTENT_TYPE) == 'application/json;charset=UTF-8'
+        resp.json.api == "version 1.0 (Non-Namespaced)"
+        resp.json.title == "API - The Shining"
+    }
 }


### PR DESCRIPTION
Addresses #127 

The idea is that using "respond" should resolve views using the same strategy as "render". Basically look for the most specific view (using the namespace), and if you don't find it, look for it again without the namespace. This lets the developer use "respond" as a drop-in replacement for "render" for namespaced controllers, making it easier to support content-negotiation.

* Include test to illustrate issue
* Use a similar strategy as GrailsConventionGroovyPageLocator to properly handle namespace strategies

Note: I attempted to follow convention where I could. Feel free to critique. I'm open to changing this solution if needed.