### PR TITLE
fix #208 - add views correctly to jar

### DIFF
--- a/gradle/src/main/groovy/grails/views/gradle/AbstractGroovyTemplatePlugin.groovy
+++ b/gradle/src/main/groovy/grails/views/gradle/AbstractGroovyTemplatePlugin.groovy
@@ -8,6 +8,7 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.artifacts.Configuration
+import org.gradle.api.file.CopySpec
 import org.gradle.api.file.FileCollection
 import org.gradle.api.tasks.SourceSet
 import org.gradle.api.tasks.SourceSetOutput
@@ -90,9 +91,16 @@ class AbstractGroovyTemplatePlugin implements Plugin<Project> {
             war.classpath = war.classpath + project.files(destDir)
         }
         allTasks.withType(Jar) { Jar jar ->
-            if(!(jar instanceof War) && jar.name != 'pathingJar' ) {
-                jar.dependsOn templateCompileTask
-                jar.from destDir
+            if(!(jar instanceof War)) {
+                if (jar.name == 'bootJar') {
+                    jar.dependsOn templateCompileTask
+                    jar.from(destDir) { CopySpec spec ->
+                        spec.into("BOOT-INF/classes")
+                    }
+                } else if(jar.name == 'jar') {
+                    jar.dependsOn templateCompileTask
+                    jar.from destDir
+                }
             }
         }
     }


### PR DESCRIPTION
I have one question on this:

I took out this code `if(!(jar instanceof War) && jar.name != 'pathingJar' )` and replaced it totally with the same solution from https://github.com/grails/grails-core/issues/11251. Logically it makes sense to because if its a pathingJar than it will do none of the code, just as the original code would do not execution of code.

I am not sure if this is entirely correct. 