### PR TITLE
Correctly implement 20% increase in output buffer size.

### DIFF
--- a/json/src/main/groovy/grails/plugin/json/builder/JsonOutput.java
+++ b/json/src/main/groovy/grails/plugin/json/builder/JsonOutput.java
@@ -178,7 +178,7 @@ public class JsonOutput {
     public static String prettyPrint(String jsonPayload) {
         int indentSize = 0;
         // Just a guess that the pretty view will take a 20 percent more than original.
-        final CharBuf output = CharBuf.create((int) (jsonPayload.length() * 0.2));
+        final CharBuf output = CharBuf.create((int) (jsonPayload.length() * 1.2));
 
         JsonLexer lexer = new JsonLexer(new StringReader(jsonPayload));
         // Will store already created indents.


### PR DESCRIPTION
The documentation states that pretty printing is estimated to take an additional 20% capacity, however, the buffer produced is 20% of the size of the unformatted JSON. This modification adjusts it to 120% of the unformatted JSON.