### PR TITLE
Remove duplicate GSON classes from War.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ subprojects { subProject->
         userOrg = "grails"
     }
     group "org.grails"
-    version "2.0.1.BUILD-SNAPSHOT"
+    version "2.1.0.BUILD-SNAPSHOT"
 //    version "2.0.1"
     repositories {
         mavenCentral()

--- a/gradle/src/main/groovy/grails/views/gradle/AbstractGroovyTemplatePlugin.groovy
+++ b/gradle/src/main/groovy/grails/views/gradle/AbstractGroovyTemplatePlugin.groovy
@@ -88,7 +88,6 @@ class AbstractGroovyTemplatePlugin implements Plugin<Project> {
 
         allTasks.withType(War) { War war ->
             war.dependsOn templateCompileTask
-            war.classpath = war.classpath + project.files(destDir)
         }
         allTasks.withType(Jar) { Jar jar ->
             if(!(jar instanceof War)) {


### PR DESCRIPTION
Removing the classpath append on the warTask as line 57 in `AbstractGroovyTemplatePlugin` appends the destination directory to the `mainSourceSet`. This causes a redundant copy.

 Fixes #216 and grails/grails-core#11429