### PR TITLE
Remove duplicate GSON classes from War

### DIFF
--- a/gradle/src/main/groovy/grails/views/gradle/AbstractGroovyTemplatePlugin.groovy
+++ b/gradle/src/main/groovy/grails/views/gradle/AbstractGroovyTemplatePlugin.groovy
@@ -88,7 +88,6 @@ class AbstractGroovyTemplatePlugin implements Plugin<Project> {
 
         allTasks.withType(War) { War war ->
             war.dependsOn templateCompileTask
-            war.classpath = war.classpath + project.files(destDir)
         }
         allTasks.withType(Jar) { Jar jar ->
             if(!(jar instanceof War)) {


### PR DESCRIPTION
Removing the classpath append on the warTask as line 57 in AbstractGroovyTemplatePlugin appends the destination directory to the mainSourceSet. This causes a redundant copy.

Fixes #216 and grails/grails-core#11429

Had to redo this PR to git right source branch.