### PR TITLE
Support platform filesystem path separators in GenericGroovyTemplateResolver.resolveTemplateName

### DIFF
--- a/core/src/main/groovy/grails/views/resolve/GenericGroovyTemplateResolver.groovy
+++ b/core/src/main/groovy/grails/views/resolve/GenericGroovyTemplateResolver.groovy
@@ -64,8 +64,8 @@ class GenericGroovyTemplateResolver implements TemplateResolver {
     }
 
     static String resolveTemplateName(String scope, String path) {
-        if(path.startsWith('/')) {
-            path = path.substring(1) // remove leading slash '/'    
+        if(path.startsWith(File.separator) || path.startsWith('/')) {
+            path = path.substring(1) // remove leading path separator 
         }
         path = path.replace(File.separatorChar, UNDERSCORE_CHAR)
         path = path.replace(SLASH_CHAR, UNDERSCORE_CHAR)


### PR DESCRIPTION
The plugin currently fails 2 test cases on Windows because of path separator differences. The problem also manifests in Grails 4.0.4 since it updated to 2.0.2 of the views plugin, on Windows Grails controllers fail to resolve GSON views and either throw an exception or fall back to a default JSON renderer.

I haven't dug into it too far, but it appears that resolveTemplateName is called in a couple of contexts, sometimes with a filesystem path and sometimes with a resource path, so I think the right thing to do is remove the filesystem or resource path separator.

I've verified that the proposed change passes the tests when built on Windows, and also fixes the GSON view resolution problem in Grails 4.0.4 on Windows.