### PR TITLE
Correct the unspecified  project version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,8 @@ if (isReleaseVersion) {
 
 subprojects { project->
 
+    version project.projectVersion
+
     configurations.all {
         resolutionStrategy.eachDependency { DependencyResolveDetails details ->
             if(details.requested.group == 'org.codehaus.groovy') {
@@ -65,8 +67,6 @@ subprojects { project->
     if (ext.isGrailsPlugin) {
         apply plugin: "org.grails.grails-plugin"
     }
-
-    version project.projectVersion
 
     sourceCompatibility = 1.8
     targetCompatibility = 1.8


### PR DESCRIPTION
Grails views json plugins published with wrong version, from version 2.1 - 2.3.

This is the info log when app started:

```
INFO --- [  restartedMain] g.plugins.DefaultGrailsPluginManager     : Grails plugin [jsonView] with version [unspecified] loaded successfully
```
