### PR TITLE
Fixing class entry duplicate error when generating bootJar

### DIFF
--- a/gradle/src/main/groovy/grails/views/gradle/AbstractGroovyTemplatePlugin.groovy
+++ b/gradle/src/main/groovy/grails/views/gradle/AbstractGroovyTemplatePlugin.groovy
@@ -86,16 +86,9 @@ class AbstractGroovyTemplatePlugin implements Plugin<Project> {
 
         templateCompileTask.dependsOn( allTasks.findByName('classes') )
 
-        allTasks.withType(War) { War war ->
-            war.dependsOn templateCompileTask
-        }
         allTasks.withType(Jar) { Jar jar ->
-            if(!(jar instanceof War)) {
-                if (jar.name == 'bootJar') {
-                    jar.dependsOn templateCompileTask
-                } else if(jar.name == 'jar') {
-                    jar.dependsOn templateCompileTask
-                }
+            if (jar.name in ['jar', 'bootJar', 'war', 'bootWar']) {
+                jar.dependsOn templateCompileTask
             }
         }
     }

--- a/gradle/src/main/groovy/grails/views/gradle/AbstractGroovyTemplatePlugin.groovy
+++ b/gradle/src/main/groovy/grails/views/gradle/AbstractGroovyTemplatePlugin.groovy
@@ -93,12 +93,8 @@ class AbstractGroovyTemplatePlugin implements Plugin<Project> {
             if(!(jar instanceof War)) {
                 if (jar.name == 'bootJar') {
                     jar.dependsOn templateCompileTask
-                    jar.from(destDir) { CopySpec spec ->
-                        spec.into("BOOT-INF/classes")
-                    }
                 } else if(jar.name == 'jar') {
                     jar.dependsOn templateCompileTask
-                    jar.from destDir
                 }
             }
         }


### PR DESCRIPTION
Fix for issue https://github.com/grails/grails-core/issues/12181

I don't know that much details about the Gradle build or what changed with newer Gradle versions, but the error happens because the classes already exist in the artifact. So I simply tried without the explicit copy of the compiled classes into the artifact and it still worked. Seems like this code is simply not needed anymore and is handled elsewhere.