### PR TITLE
Make includes work in both editor and gradle.

### DIFF
--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -16,9 +16,12 @@ repositories {
 }
 
 asciidoctor {
+
+    baseDirFollowsSourceDir()
+
     resources {
-        from('src/docs/images')
-        into "./images"
+        from 'src/docs/images'
+        into './images'
     }
 
     attributes 'experimental'  : 'true',

--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -17,7 +17,7 @@ repositories {
 
 asciidoctor {
 
-    baseDirFollowsSourceDir()
+     baseDirFollowsSourceFile()
 
     resources {
         from 'src/docs/images'

--- a/docs/src/docs/asciidoc/index.adoc
+++ b/docs/src/docs/asciidoc/index.adoc
@@ -1,4 +1,3 @@
-:includedir: src/docs/asciidoc/
 = Grails Views
 
 :author: Graeme Rocher
@@ -8,10 +7,10 @@
 
 :leveloffset: +1
 
-include::{includedir}introduction.adoc[]
+include::introduction.adoc[]
 
-include::{includedir}json/index.adoc[]
+include::json/index.adoc[]
 
-include::{includedir}markup/index.adoc[]
+include::markup/index.adoc[]
 
 :leveloffset: -1


### PR DESCRIPTION
When viewing the asciidoc source in Intellij, the included files cannot be resolved when using `:includedir:`.
Without the `:includedir:` gradle cannot resolve the files.
By using `baseDirFollowsSourceDir()` in the gradle asciidoctor task `{includedir}` can be removed from the include paths and it seems to work in both places.
