### PR TITLE
Gradle 7: use destinationDirectory property instead, because Abstract…

### DIFF
--- a/gradle/src/main/groovy/grails/views/gradle/AbstractGroovyTemplateCompileTask.groovy
+++ b/gradle/src/main/groovy/grails/views/gradle/AbstractGroovyTemplateCompileTask.groovy
@@ -14,6 +14,7 @@ import org.gradle.api.tasks.compile.AbstractCompile
 import org.gradle.api.tasks.incremental.IncrementalTaskInputs
 import org.gradle.process.ExecResult
 import org.gradle.process.JavaExecSpec
+import org.gradle.work.InputChanges
 
 /**
  * Abstract Gradle task for compiling templates, using GenericGroovyTemplateCompiler
@@ -48,7 +49,7 @@ abstract class AbstractGroovyTemplateCompileTask extends AbstractCompile {
     }
 
     @TaskAction
-    void execute(IncrementalTaskInputs inputs) {
+    void execute(InputChanges inputs) {
         compile()
     }
 
@@ -81,7 +82,7 @@ abstract class AbstractGroovyTemplateCompileTask extends AbstractCompile {
                         String packageImports = projectPackageNames.join(',') ?: packageName
                         def arguments = [
                                 srcDir.canonicalPath,
-                                destinationDir.canonicalPath,
+                                destinationDirectory.getAsFile().get()?.canonicalPath,
                                 targetCompatibility,
                                 packageImports,
                                 packageName,

--- a/gradle/src/main/groovy/grails/views/gradle/AbstractGroovyTemplatePlugin.groovy
+++ b/gradle/src/main/groovy/grails/views/gradle/AbstractGroovyTemplatePlugin.groovy
@@ -75,7 +75,7 @@ class AbstractGroovyTemplatePlugin implements Plugin<Project> {
             allClasspath += providedConfig
         }
 
-        templateCompileTask.setDestinationDir( destDir )
+        templateCompileTask.getDestinationDirectory().set( destDir )
         templateCompileTask.setClasspath( allClasspath )
         templateCompileTask.setPackageName(
                 project.name


### PR DESCRIPTION
…Compile.destinationDir property has been deprecated.