### PR TITLE
feat(core): Added support for multi-template inheritance.

### DIFF
--- a/docs/src/docs/asciidoc/json/history.adoc
+++ b/docs/src/docs/asciidoc/json/history.adoc
@@ -2,6 +2,8 @@
 
 The current release is {version}. Below is a version history.
 
+For later releases check the release notes at: https://github.com/grails/grails-views/releases
+
 *2.0.2*
 
 * Fix bug where incorrect JSON was generated when all values are null in the nested object.

--- a/json/grails-app/views/_child2MultipleParents.gson
+++ b/json/grails-app/views/_child2MultipleParents.gson
@@ -1,0 +1,9 @@
+import grails.plugin.json.view.Player
+import groovy.transform.Field
+
+inherits(template: 'parent2')
+inherits(template: 'parent4')
+
+@Field Player player
+
+json g.render(player)

--- a/json/grails-app/views/_child3MultipleParents.gson
+++ b/json/grails-app/views/_child3MultipleParents.gson
@@ -1,0 +1,9 @@
+import grails.plugin.json.view.Player
+import groovy.transform.Field
+
+inherits(template: 'parent3')
+inherits(template: 'parent4')
+
+@Field Player player
+
+json g.render(player, [includes:'name'])

--- a/json/grails-app/views/_child4MultipleParents.gson
+++ b/json/grails-app/views/_child4MultipleParents.gson
@@ -1,0 +1,11 @@
+import grails.plugin.json.view.Player
+import groovy.transform.Field
+
+inherits(template: 'parent2')
+inherits(template: 'parent4')
+
+@Field Player player
+
+json {
+    name player.name
+}

--- a/json/grails-app/views/_parent4.gson
+++ b/json/grails-app/views/_parent4.gson
@@ -1,0 +1,7 @@
+import groovy.transform.Field
+
+@Field Object object
+
+json {
+    bar "foo"
+}

--- a/json/src/main/groovy/grails/plugin/json/view/api/JsonView.groovy
+++ b/json/src/main/groovy/grails/plugin/json/view/api/JsonView.groovy
@@ -5,6 +5,7 @@ import grails.plugin.json.builder.StreamingJsonBuilder
 import grails.plugin.json.view.api.internal.DefaultGrailsJsonViewHelper
 import grails.plugin.json.view.api.internal.DefaultHalViewHelper
 import grails.plugin.json.view.api.internal.DefaultJsonApiViewHelper
+import grails.plugin.json.view.api.internal.ParentInfo
 import grails.plugin.json.view.api.internal.TemplateRenderer
 import grails.plugin.json.view.api.jsonapi.JsonApiIdRenderStrategy
 import grails.views.GrailsViewTemplate
@@ -21,7 +22,6 @@ import groovy.transform.CompileStatic
  */
 @CompileStatic
 trait JsonView extends GrailsView {
-
     /**
      * The default generator
      */
@@ -37,15 +37,7 @@ trait JsonView extends GrailsView {
      */
     StreamingJsonBuilder json
 
-    /**
-     * The parent template if any
-     */
-    GrailsViewTemplate parentTemplate
-
-    /**
-     * The parent model, if any
-     */
-    Map parentModel
+    Collection<ParentInfo> parentData = []
     /**
      * Overrides the default helper with new methods specific to JSON building
      */
@@ -91,8 +83,11 @@ trait JsonView extends GrailsView {
                     .resolveTemplateUri(getControllerNamespace(), getControllerName(), template.toString())
             GrailsViewTemplate parentTemplate = (GrailsViewTemplate)templateEngine.resolveTemplate(templateUri, locale)
             if(parentTemplate != null) {
-                this.parentTemplate = parentTemplate
-                this.parentModel = model
+                ParentInfo parentInfo = new ParentInfo(
+                    parentTemplate: parentTemplate,
+                    parentModel: model
+                )
+                parentData.add(parentInfo)
             }
             else {
                 throw new ViewException("Template not found for name $template")

--- a/json/src/main/groovy/grails/plugin/json/view/api/internal/ParentInfo.groovy
+++ b/json/src/main/groovy/grails/plugin/json/view/api/internal/ParentInfo.groovy
@@ -1,0 +1,17 @@
+package grails.plugin.json.view.api.internal
+
+import grails.views.GrailsViewTemplate
+import groovy.transform.CompileStatic
+
+@CompileStatic
+class ParentInfo {
+    /**
+     * The parent template if any
+     */
+    GrailsViewTemplate parentTemplate
+
+    /**
+     * The parent model, if any
+     */
+    Map parentModel
+}

--- a/json/src/test/groovy/grails/plugin/json/view/TemplateInheritanceSpec.groovy
+++ b/json/src/test/groovy/grails/plugin/json/view/TemplateInheritanceSpec.groovy
@@ -44,4 +44,31 @@ class TemplateInheritanceSpec extends Specification implements JsonViewTest {
         result.jsonText == '{"name":"Cantona"}'
     }
 
+    void "test extending multiple templates"() {
+        when:
+
+        def result = render(template:'child2MultipleParents', model:[player: new Player(name: "Cantona")])
+        then:
+        result.jsonText == '{"_links":{"self":{"href":"http://localhost:8080/player","hreflang":"en","type":"application/hal+json"}},"foo":"bar","bar":"foo","name":"Cantona"}'
+    }
+
+    void "test extending multiple templates that uses g.render(..)"() {
+
+        when:
+        def player = new Player(name: "Cantona")
+        player.id = 1L
+        def result = render(template:'child3MultipleParents', model:[player: player])
+        then:
+        result.jsonText == '{"id":1,"bar":"foo","name":"Cantona"}'
+    }
+
+    void "test extending multiple templates and rendering a JSON block"() {
+        when:
+
+        def result = render(template:'child4MultipleParents', model:[player: new Player(name: "Cantona")])
+        then:
+        result.jsonText == '{"_links":{"self":{"href":"http://localhost:8080/player","hreflang":"en","type":"application/hal+json"}},"foo":"bar","bar":"foo","name":"Cantona"}'
+    }
+
+
 }


### PR DESCRIPTION
Sometimes it can be useful to use multi-template inheritance e.g. in case of using of Traits or Interfaces.
With this patch it is possible to do that by just using "inherits" multiple time in gson file.

```
inherits(template: 'parent2')
inherits(template: 'parent4')
```
