### PR TITLE
As using only [version] instead of [project.version] (in docs/build.g…

### DIFF
--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -25,7 +25,7 @@ asciidoctor {
                'compat-mode'   : 'true',
                'toc'           : 'left',
                'icons'         : 'font',
-               'version'       : project.version,
+               'version'       : version,
                'sourcedir'     : "${rootProject.allprojects.find { it.name == 'views-core'}.projectDir}/src/main/groovy"
 }
 


### PR DESCRIPTION
…radle) seems to work in the apidocs task (for the docTitle) it should also resolve correctly in the asciidoctor task to render the current version instead of 'undefined'. Fixes #420