### PR TITLE
chore(build): Remove redundant junit dependency declarations

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -101,10 +101,6 @@ subprojects { subproject->
             documentation "com.github.javaparser:javaparser-core:$javaParserCoreVersion"
 
             testImplementation "org.spockframework:spock-core:$spockVersion"
-            testImplementation "org.codehaus.groovy:groovy-test-junit5:${groovyVersion}"
-            testImplementation "org.junit.jupiter:junit-jupiter-api:5.9.3"
-            testImplementation "org.junit.platform:junit-platform-runner:1.9.3"
-            testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:5.9.3"
         }
 
         tasks.withType(Test) {


### PR DESCRIPTION
These are not being used directly in source code and the ones that are used are being pulled in transitively anyway. They cause problems when renovate updates them.