### PR TITLE
chore(build): Migrate to Develocity build cache connector

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -8,7 +8,7 @@ gradleEnterprise {
     buildScan {
         publishAlwaysIf(System.getenv('CI') == 'true')
         publishIfAuthenticated()
-        uploadInBackground = System.getenv('CI') == null
+        uploadInBackground = System.getenv("CI") == null
         capture {
             taskInputFiles = true
         }
@@ -17,14 +17,10 @@ gradleEnterprise {
 
 buildCache {
     local { enabled = System.getenv('CI') != 'true' }
-    remote(HttpBuildCache) {
-        push = System.getenv('CI') == 'true'
+    remote(gradleEnterprise.buildCache) {
+        def isAuthenticated = System.getenv('GRADLE_ENTERPRISE_ACCESS_KEY')
+        push = System.getenv('CI') == 'true' && isAuthenticated
         enabled = true
-        url = 'https://ge.grails.org/cache/'
-        credentials {
-            username = System.getenv('GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER')
-            password = System.getenv('GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY')
-        }
     }
 }
 


### PR DESCRIPTION
To simplify cache management with  the [Develocity cache connector](https://docs.gradle.com/enterprise/gradle-plugin/#using_the_develocity_connector)