### PR TITLE
fix(build): Set Sonatype repo url in build file

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,6 @@ jobs:
           ORG_GRADLE_PROJECT_sonatypeOssUsername: ${{ secrets.SONATYPE_USERNAME }}
           ORG_GRADLE_PROJECT_sonatypeOssPassword: ${{ secrets.SONATYPE_PASSWORD }}
           ORG_GRADLE_PROJECT_sonatypeOssStagingProfileId: ${{ secrets.SONATYPE_STAGING_PROFILE_ID }}
-          ORG_GRADLE_PROJECT_sonatypeOssRepo: 'https://s01.oss.sonatype.org/service/local/'
           SIGNING_KEY: ${{ secrets.SIGNING_KEY }}
           SIGNING_PASSPHRASE: ${{ secrets.SIGNING_PASSPHRASE }}
         with:

--- a/build.gradle
+++ b/build.gradle
@@ -70,10 +70,9 @@ if (isReleaseVersion) {
         String ossUser = project.findProperty('sonatypeOssUsername') ?: ''
         String ossPass = project.findProperty('sonatypeOssPassword') ?: ''
         String ossStagingProfileId = project.findProperty('sonatypeOssStagingProfileId') ?: ''
-        String ossRepo = project.findProperty('sonatypeOssRepo') ?: ''
         repositories {
             sonatype {
-                nexusUrl = uri(ossRepo)
+                nexusUrl = uri('https://s01.oss.sonatype.org/service/local/')
                 username = ossUser
                 password = ossPass
                 stagingProfileId = ossStagingProfileId


### PR DESCRIPTION
Release failed when initializing the nexus staging repository: Expected URL scheme 'http' or 'https' but was 'file'.

It looks like the property was not read from release.yml. Hard-coding it in the build file instead.