### PR TITLE
fix(release): Separate the publications

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
         if: success()
         uses: actions/upload-artifact@v4
         with:
-          name: grails-views-${{ steps.release_version.outputs.value }}.zip
+          name: grails-views-${{ steps.release_version.outputs.value }}
           path: ./**/build/libs/*
       - name: Generate key file for artifact signing
         env:

--- a/build.gradle
+++ b/build.gradle
@@ -10,6 +10,9 @@ version = projectVersion
 ext.set('grailsVersion', libs.versions.grails.asProvider().get())
 ext.set('isSnapshot', version.endsWith('-SNAPSHOT'))
 ext.set('isReleaseVersion', !isSnapshot)
+ext.set('signing.keyId', findProperty('signing.keyId') ?: System.getenv('SIGNING_KEY'))
+ext.set('signing.password', findProperty('signing.password') ?: System.getenv('SIGNING_PASSPHRASE'))
+ext.set('signing.secretKeyRingFile', findProperty('signing.secretKeyRingFile') ?: "${System.properties['user.home']}${File.separator}.gnupg${File.separator}secring.gpg")
 ext.set('pomInfo', {
     delegate.url 'https://views.grails.org/latest/'
     delegate.licenses {
@@ -63,14 +66,17 @@ allprojects {
                 'Implementation-Vendor': 'grails.org'
         )
     }
+    tasks.withType(Sign).configureEach {
+        onlyIf { isReleaseVersion }
+    }
 }
 
 if (isReleaseVersion) {
     nexusPublishing {
-        String ossUser = project.findProperty('sonatypeOssUsername')
-        String ossPass = project.findProperty('sonatypeOssPassword')
-        String ossStagingProfileId = project.findProperty('sonatypeOssStagingProfileId')
-        String ossRepo = project.findProperty('sonatypeOssRepo') ?: 'https://s01.oss.sonatype.org/service/local/'
+        String ossUser = findProperty('sonatypeOssUsername')
+        String ossPass = findProperty('sonatypeOssPassword')
+        String ossStagingProfileId = findProperty('sonatypeOssStagingProfileId')
+        String ossRepo = findProperty('sonatypeOssRepo') ?: 'https://s01.oss.sonatype.org/service/local/'
         repositories {
             sonatype {
                 nexusUrl = uri(ossRepo)

--- a/gradle-plugin/build.gradle
+++ b/gradle-plugin/build.gradle
@@ -37,25 +37,35 @@ gradlePlugin {
 	}
 }
 
-// This is for signing and publishing the Gradle Plugin Marker poms
+// Signing and publishing for this project is handled
+// separately as it is using the java-gradle-plugin
 afterEvaluate {
+	def publications = extensions.findByType(PublishingExtension).publications
 	signing {
 		required = { isReleaseVersion && gradle.taskGraph.hasTask('publish') }
-		def publicationContainer = project.extensions.findByType(PublishingExtension).publications
-		def publicationsToSign = publicationContainer.stream().filter { it.name != 'pluginMaven' }.toArray(Publication[]::new)
-		sign(publicationsToSign)
+		sign(publications.withType(MavenPublication))
 	}
-	publishing.publications.each { publication ->
-		def pub = publication as MavenPublication
-		if (pub.name != 'pluginMaven') {
-			pub.pom.withXml {
-				def xml = asNode()
-				xml.children().last() + pomInfo
-			}
+	// Modify the 'pluginMaven' publication that is already
+	// set up by the java-gradle-plugin for the java components
+	publications.named('pluginMaven', MavenPublication) {
+		artifactId = project.name
+		versionMapping {
+			usage('java-api') { fromResolutionOf('runtimeClasspath') }
+			usage('java-runtime') { fromResolutionResult() }
+		}
+		pom {
+			name = 'Grails Views'
+			description = 'Provides additional view technologies to the Grails framework, including JSON and Markup views.'
+		}
+	}
+	// Add our pom info to all publications
+	// (e.g. also to the plugin marker poms)
+	publications.withType(MavenPublication).each {
+		it.pom.withXml {
+			asNode().children().last() + pomInfo
 		}
 	}
 }
 
 apply from: rootProject.layout.projectDirectory.file('gradle/java-config.gradle')
 apply from: rootProject.layout.projectDirectory.file('gradle/api-docs-config.gradle')
-apply from: rootProject.layout.projectDirectory.file('gradle/publishing.gradle')

--- a/gradle/publishing.gradle
+++ b/gradle/publishing.gradle
@@ -1,20 +1,8 @@
-ext.set('signing.keyId', project.findProperty('signing.keyId') ?: System.getenv('SIGNING_KEY'))
-ext.set('signing.password', project.findProperty('signing.password') ?: System.getenv('SIGNING_PASSPHRASE'))
-ext.set('signing.secretKeyRingFile', project.findProperty('signing.secretKeyRingFile') ?: "${System.properties['user.home']}${File.separator}.gnupg${File.separator}secring.gpg")
-
 def javaComponent = components.named('java')
 project.extensions.configure(PublishingExtension) { PublishingExtension pe ->
-
-    // 'java-gradle-plugin' in views-gradle has already created this publication
-    if (!pe.publications.names.contains('pluginMaven')) {
-        pe.publications.register('pluginMaven', MavenPublication)
-    }
-    pe.publications.named('pluginMaven', MavenPublication) {
+    pe.publications.register('maven', MavenPublication) {
         artifactId = project.name
-        // 'java-gradle-plugin' in views-gradle has already configured this
-        if (project.name != 'views-gradle') {
-            from javaComponent.get()
-        }
+        from javaComponent.get()
         versionMapping {
             usage('java-api') { fromResolutionOf('runtimeClasspath') }
             usage('java-runtime') { fromResolutionResult() }
@@ -26,7 +14,6 @@ project.extensions.configure(PublishingExtension) { PublishingExtension pe ->
         pom.withXml {
             def pomNode = asNode()
             pomNode.children().last() + pomInfo
-
             // dependency management shouldn't be included
             try { pomNode.dependencyManagement.replaceNode({}) } catch (Throwable ignore) {}
         }
@@ -48,18 +35,12 @@ project.extensions.configure(PublishingExtension) { PublishingExtension pe ->
 }
 
 afterEvaluate {
-    def publicationContainer = extensions.findByType(PublishingExtension).publications
+    def publications = extensions.findByType(PublishingExtension).publications
     extensions.configure(SigningExtension) { SigningExtension se ->
         se.required = { isReleaseVersion && gradle.taskGraph.hasTask('publish') }
-        def publicationsToSign = publicationContainer.stream().filter { it.name == 'pluginMaven' }.toArray(Publication[]::new)
-        se.sign(publicationsToSign)
+        se.sign(publications.named('maven').get())
     }
 }
-
-tasks.withType(Sign).configureEach {
-    onlyIf { isReleaseVersion }
-}
-
 tasks.register('install') {
     dependsOn 'publishToMavenLocal'
 }


### PR DESCRIPTION
Create publications under different names and
handle publishing of the views-gradle
project separately.