### PR TITLE
fix(release): Turn off parallel mode for publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,7 +57,8 @@ jobs:
           SIGNING_PASSPHRASE: ${{ secrets.SIGNING_PASSPHRASE }}
         with:
           arguments: |
-            -Psigning.secretKeyRingFile=${{ github.workspace }}/secring.gpg 
+            -Psigning.secretKeyRingFile=${{ github.workspace }}/secring.gpg
+            -Porg.gradle.parallel=false
             publishToSonatype 
             closeSonatypeStagingRepository
   release:

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-projectVersion=3.2.0-SNAPSHOT
+projectVersion=3.2.0
 
 # This prevents the Grails Gradle Plugin from unnecessarily excluding slf4j-simple in the generated POMs
 # https://github.com/grails/grails-gradle-plugin/issues/222

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-projectVersion=3.2.0
+projectVersion=3.2.0-SNAPSHOT
 
 # This prevents the Grails Gradle Plugin from unnecessarily excluding slf4j-simple in the generated POMs
 # https://github.com/grails/grails-gradle-plugin/issues/222


### PR DESCRIPTION
Failures happen intermittently when creating pom files.
Trying to turn of parallel mode when publishing if there is a concurrency issue at hand here.