### PR TITLE
chore(reelase): add root-project groupid

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,6 +6,7 @@ plugins {
     id 'org.asciidoctor.jvm.convert'
 }
 
+group = 'org.grails'
 version = projectVersion
 ext.set('grailsVersion', libs.versions.grails.asProvider().get())
 ext.set('isSnapshot', version.endsWith('-SNAPSHOT'))


### PR DESCRIPTION
Define `group` for rootProject so that nexus-publish plugin correctly matches staging repository via Gradle task `findSonatypeStagingRepo`.

This is suggested in gradle-nexus/publish-plugin#310.