### PR TITLE
chore(ci): auto-label pull-requests

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -5,6 +5,72 @@ pull-request:
     fix: '🐛 $TITLE (#$NUMBER)'
     feat: '🚀 $TITLE (#$NUMBER)'
     default: '$TITLE (#$NUMBER)'
+autolabeler:
+  - label: 'bug'
+    branch:
+      - '/fix\/.+/'
+    title:
+      - '/fix/i'
+  - label: 'feature'
+    branch:
+      - '/feature\/.+/'
+    title:
+      - '/feat/i'
+  - label: 'documentation'
+    branch:
+      - '/docs\/.+/'
+    title:
+      - '/docs/i'
+  - label: 'maintenance'
+    branch:
+      - '/(chore|refactor|style|test|ci|perf|build|deps)\/.+/'
+    title:
+      - '/(chore|refactor|style|test|ci|perf|build|deps)/i'
+  - label: 'chore'
+    branch:
+      - '/chore\/.+/'
+    title:
+      - '/chore/i'
+  - label: 'refactor'
+    branch:
+      - '/refactor\/.+/'
+    title:
+      - '/refactor/i'
+  - label: 'style'
+    branch:
+      - '/style\/.+/'
+    title:
+      - '/style/i'
+  - label: 'test'
+    branch:
+      - '/test\/.+/'
+    title:
+      - '/test/i'
+  - label: 'ci'
+    branch:
+      - '/ci\/.+/'
+    title:
+      - '/ci/i'
+  - label: 'perf'
+    branch:
+      - '/perf\/.+/'
+    title:
+      - '/perf/i'
+  - label: 'build'
+    branch:
+      - '/build\/.+/'
+    title:
+      - '/build/i'
+  - label: 'deps'
+    branch:
+      - '/deps\/.+/'
+    title:
+      - '/deps/i'
+  - label: 'revert'
+    branch:
+      - '/revert\/.+/'
+    title:
+      - '/revert/i'
 categories:
   - title: '🚀 Features'
     labels:


### PR DESCRIPTION
Update release-drafter/release-drafter configurations to add autolabeler config so it automatically labels pull requests.