### PR TITLE
chore(releasenotes): udpate workflow configurations

### DIFF
--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -6,6 +6,10 @@ on:
     branches:
       - master
       - '[2-9]+.[0-9]+.x'
+  pull_request:
+    types: [opened, reopened, synchronize]
+  pull_request_target:
+     types: [opened, reopened, synchronize]
   workflow_dispatch:
 jobs:
   release_notes:


### PR DESCRIPTION
* pull_request event is required only for autolabeler
* pull_request_target event is required for autolabeler to support PRs from forks