### PR TITLE
Decouple `views-gradle-plugin` from dependencies

### DIFF
--- a/gradle-plugin/build.gradle
+++ b/gradle-plugin/build.gradle
@@ -13,7 +13,6 @@ dependencies {
     // the gradle api is provided by java-gradle-plugin
 
     implementation platform(libs.grails.bom)
-    implementation libs.grails.gradle.plugin
     implementation libs.jakarta.annotation.api
 
     compileOnly libs.groovy.core // @CompileStatic

--- a/gradle-plugin/build.gradle
+++ b/gradle-plugin/build.gradle
@@ -13,12 +13,7 @@ dependencies {
     // the gradle api is provided by java-gradle-plugin
 
     implementation platform(libs.grails.bom)
-    implementation libs.grails.bootstrap, {
-        // grails-bootstrap leaks groovy-xml which is a problem for Gradle (version conflict)
-        exclude group: 'org.codehaus.groovy', module: 'groovy-xml'
-    }
     implementation libs.grails.gradle.plugin
-    implementation libs.spring.boot.gradle.plugin
     implementation libs.jakarta.annotation.api
 
     compileOnly libs.groovy.core // @CompileStatic

--- a/gradle-plugin/src/main/groovy/grails/views/gradle/AbstractGroovyTemplatePlugin.groovy
+++ b/gradle-plugin/src/main/groovy/grails/views/gradle/AbstractGroovyTemplatePlugin.groovy
@@ -1,6 +1,7 @@
 package grails.views.gradle
 
 import grails.views.gradle.util.GrailsNameUtils
+import grails.views.gradle.util.SourceSets
 import groovy.transform.CompileDynamic
 import groovy.transform.CompileStatic
 import org.apache.tools.ant.taskdefs.condition.Os
@@ -12,9 +13,6 @@ import org.gradle.api.file.FileCollection
 import org.gradle.api.tasks.SourceSetOutput
 import org.gradle.api.tasks.TaskContainer
 import org.gradle.api.tasks.bundling.Jar
-import org.grails.gradle.plugin.core.GrailsExtension
-import org.grails.gradle.plugin.core.IntegrationTestGradlePlugin
-import org.grails.gradle.plugin.util.SourceSets
 
 /**
  * Abstract implementation of a plugin that compiles views
@@ -42,6 +40,7 @@ class AbstractGroovyTemplatePlugin implements Plugin<Project> {
     }
 
     @Override
+    @CompileDynamic
     void apply(Project project) {
         TaskContainer tasks = project.tasks
         String upperCaseName = GrailsNameUtils.getClassName(fileExtension)
@@ -54,8 +53,8 @@ class AbstractGroovyTemplatePlugin implements Plugin<Project> {
         File destDir = new File(project.layout.buildDirectory.get().asFile, "${templateCompileTask.fileExtension.get()}-classes/main")
         output?.dir(destDir)
         project.afterEvaluate {
-            GrailsExtension grailsExt = project.extensions.getByType(GrailsExtension)
-            if (grailsExt.pathingJar && Os.isFamily(Os.FAMILY_WINDOWS)) {
+            def grailsExt = project.extensions.findByName('grails')
+            if (grailsExt?.pathingJar && Os.isFamily(Os.FAMILY_WINDOWS)) {
                 Jar pathingJar = (Jar) tasks.named('pathingJar').get()
                 ConfigurableFileCollection allClasspath = project.files(
                         "${project.layout.buildDirectory.get().asFile}/classes/groovy/main",
@@ -83,7 +82,7 @@ class AbstractGroovyTemplatePlugin implements Plugin<Project> {
                 task.dependsOn(templateCompileTask)
             }
         }
-        project.plugins.withType(IntegrationTestGradlePlugin).configureEach {
+        project.plugins.withId('org.grails.gradle.plugin.core.IntegrationTestGradlePlugin') {
             tasks.named('compileIntegrationTestGroovy') { Task task ->
                 task.dependsOn(templateCompileTask)
             }

--- a/gradle-plugin/src/main/groovy/grails/views/gradle/AbstractGroovyTemplatePlugin.groovy
+++ b/gradle-plugin/src/main/groovy/grails/views/gradle/AbstractGroovyTemplatePlugin.groovy
@@ -1,6 +1,5 @@
 package grails.views.gradle
 
-import grails.util.GrailsNameUtils
 import groovy.transform.CompileDynamic
 import groovy.transform.CompileStatic
 import org.apache.tools.ant.taskdefs.condition.Os
@@ -15,8 +14,6 @@ import org.gradle.api.tasks.bundling.Jar
 import org.grails.gradle.plugin.core.GrailsExtension
 import org.grails.gradle.plugin.core.IntegrationTestGradlePlugin
 import org.grails.gradle.plugin.util.SourceSets
-import org.springframework.boot.gradle.plugin.ResolveMainClassName
-import org.springframework.boot.gradle.plugin.SpringBootPlugin
 
 /**
  * Abstract implementation of a plugin that compiles views
@@ -75,14 +72,14 @@ class AbstractGroovyTemplatePlugin implements Plugin<Project> {
         templateCompileTask.packageName.set(project.name)
         templateCompileTask.setSource(project.file("${project.projectDir}/$pathToSource"))
         templateCompileTask.dependsOn(tasks.named('classes').get())
-        project.plugins.withType(SpringBootPlugin).configureEach {plugin ->
+        project.plugins.withId('org.springframework.boot') {
             tasks.withType(Jar).configureEach { Task task ->
                 if (task.name in ['jar', 'bootJar', 'war', 'bootWar']) {
                     task.dependsOn(templateCompileTask)
                 }
             }
-            tasks.withType(ResolveMainClassName).configureEach {
-                it.dependsOn(templateCompileTask)
+            tasks.named('resolveMainClassName').configure { Task task ->
+                task.dependsOn(templateCompileTask)
             }
         }
         project.plugins.withType(IntegrationTestGradlePlugin).configureEach {

--- a/gradle-plugin/src/main/groovy/grails/views/gradle/AbstractGroovyTemplatePlugin.groovy
+++ b/gradle-plugin/src/main/groovy/grails/views/gradle/AbstractGroovyTemplatePlugin.groovy
@@ -1,5 +1,6 @@
 package grails.views.gradle
 
+import grails.views.gradle.util.GrailsNameUtils
 import groovy.transform.CompileDynamic
 import groovy.transform.CompileStatic
 import org.apache.tools.ant.taskdefs.condition.Os

--- a/gradle-plugin/src/main/groovy/grails/views/gradle/AbstractGroovyTemplatePlugin.groovy
+++ b/gradle-plugin/src/main/groovy/grails/views/gradle/AbstractGroovyTemplatePlugin.groovy
@@ -72,23 +72,19 @@ class AbstractGroovyTemplatePlugin implements Plugin<Project> {
         templateCompileTask.packageName.set(project.name)
         templateCompileTask.setSource(project.file("${project.projectDir}/$pathToSource"))
         templateCompileTask.dependsOn(tasks.named('classes').get())
-        project.plugins.withId('org.springframework.boot') {
-            tasks.withType(Jar).configureEach { Task task ->
-                if (task.name in ['jar', 'bootJar', 'war', 'bootWar']) {
-                    task.dependsOn(templateCompileTask)
-                }
-            }
-            tasks.named('resolveMainClassName').configure { Task task ->
+        tasks.withType(Jar).configureEach { Task task ->
+            if (task.name in ['jar', 'bootJar', 'war', 'bootWar']) {
                 task.dependsOn(templateCompileTask)
             }
         }
-        project.plugins.withId('org.grails.gradle.plugin.core.IntegrationTestGradlePlugin') {
-            tasks.named('compileIntegrationTestGroovy') { Task task ->
-                task.dependsOn(templateCompileTask)
-            }
-            tasks.named('integrationTest') { Task task ->
-                task.dependsOn(templateCompileTask)
-            }
+        tasks.named('resolveMainClassName').configure { Task task ->
+            task.dependsOn(templateCompileTask)
+        }
+        tasks.named('compileIntegrationTestGroovy').configure { Task task ->
+            task.dependsOn(templateCompileTask)
+        }
+        tasks.named('integrationTest').configure { Task task ->
+            task.dependsOn(templateCompileTask)
         }
     }
 

--- a/gradle-plugin/src/main/groovy/grails/views/gradle/GrailsNameUtils.groovy
+++ b/gradle-plugin/src/main/groovy/grails/views/gradle/GrailsNameUtils.groovy
@@ -1,0 +1,59 @@
+package grails.views.gradle
+
+import groovy.transform.CompileStatic
+
+/**
+ * This class is copying some methods from GrailsNameUtils in grails-bootstrap.
+ * This is done to avoid a dependency on grails-bootstrap.
+ * GrailsNameUtils in grails-bootstrap is probably a candidate for moving to a future "grails-common" module.
+ */
+@CompileStatic
+class GrailsNameUtils {
+
+    /**
+     * Returns the class name for the given logical name and trailing name. For example "person" and "Controller" would evaluate to "PersonController"
+     *
+     * @param logicalName The logical name
+     * @param trailingName The trailing name
+     * @return The class name
+     */
+    static String getClassName(String logicalName, String trailingName) {
+        if (isBlank(logicalName)) {
+            throw new IllegalArgumentException('Argument [logicalName] cannot be null or blank');
+        }
+
+        String className = logicalName.substring(0,1).toUpperCase(Locale.ENGLISH) + logicalName.substring(1);
+        if (trailingName != null) {
+            className = className + trailingName;
+        }
+        return className;
+    }
+
+    /**
+     * Return the class name for the given logical name. For example "person" would evaluate to "Person"
+     *
+     * @param logicalName The logical name
+     * @return The class name
+     */
+    static String getClassName(String logicalName) {
+        return getClassName(logicalName, '');
+    }
+
+    /**
+     * <p>Determines whether a given string is <code>null</code>, empty,
+     * or only contains whitespace. If it contains anything other than
+     * whitespace then the string is not considered to be blank and the
+     * method returns <code>false</code>.</p>
+     * <p>We could use Commons Lang for this, but we don't want GrailsNameUtils
+     * to have a dependency on any external library to minimise the number of
+     * dependencies required to bootstrap Grails.</p>
+     * @param str The string to test.
+     * @return <code>true</code> if the string is <code>null</code>, or
+     * blank.
+     */
+    static boolean isBlank(String str) {
+        return str == null || str.trim().isEmpty();
+    }
+
+}
+

--- a/gradle-plugin/src/main/groovy/grails/views/gradle/util/GrailsNameUtils.groovy
+++ b/gradle-plugin/src/main/groovy/grails/views/gradle/util/GrailsNameUtils.groovy
@@ -1,4 +1,4 @@
-package grails.views.gradle
+package grails.views.gradle.util
 
 import groovy.transform.CompileStatic
 

--- a/gradle-plugin/src/main/groovy/grails/views/gradle/util/SourceSets.groovy
+++ b/gradle-plugin/src/main/groovy/grails/views/gradle/util/SourceSets.groovy
@@ -1,0 +1,46 @@
+package grails.views.gradle.util
+
+import groovy.transform.CompileStatic
+import org.gradle.api.Project
+import org.gradle.api.plugins.JavaPluginExtension
+import org.gradle.api.tasks.SourceSet
+import org.gradle.api.tasks.SourceSetContainer
+
+/**
+ * Copied from grails-gradle-plugin to remove the dependency on that plugin.
+ * This is a possible candidate for a future "grails-common" module.
+ *
+ * @author Graeme Rocher
+ * @since 3.0
+ */
+@CompileStatic
+class SourceSets {
+
+    /**
+     * Finds the main SourceSet for the project
+     * @param project The project
+     * @return The main source set or null if it can't be found
+     */
+    static SourceSet findMainSourceSet(Project project) {
+        return findSourceSet(project, SourceSet.MAIN_SOURCE_SET_NAME)
+    }
+
+    /**
+     * Finds the main SourceSet for the project
+     * @param project The project
+     * @return The main source set or null if it can't be found
+     */
+    static SourceSet findSourceSet(Project project, String name) {
+        SourceSetContainer sourceSets = findSourceSets(project)
+        return sourceSets?.find { SourceSet sourceSet ->
+            sourceSet.name == name
+        } as SourceSet
+    }
+
+    static SourceSetContainer findSourceSets(Project project) {
+        JavaPluginExtension plugin = project.extensions.getByType(JavaPluginExtension)
+        SourceSetContainer sourceSets = plugin?.sourceSets
+        return sourceSets
+    }
+}
+


### PR DESCRIPTION
This commit decouples the `views-gradle-plugin` from `grails-bootstrap`, `spring-boot-gradle-plugin`, `grails-gradle-plugin` dependencies.

The decoupling is intended to mitigate potential circular dependency issues during releases.