### PR TITLE
Update example project to set hibernate-ehcache dependency

### DIFF
--- a/examples/functional-tests/build.gradle
+++ b/examples/functional-tests/build.gradle
@@ -26,6 +26,13 @@ dependencies {
 
     implementation 'org.grails.plugins:gsp'
     implementation 'org.grails.plugins:hibernate5'
+    runtimeOnly "org.hibernate:hibernate-ehcache:$hibernateVersion", {
+        // exclude javax variant of hibernate-core
+        exclude group: 'org.hibernate', module: 'hibernate-core'
+    }
+    runtimeOnly "org.jboss.spec.javax.transaction:jboss-transaction-api_1.3_spec:$jbossTransactionApiVersion", {
+        // required for hibernate-ehcache to work with javax variant of hibernate-core excluded
+    }
 
     implementation 'org.springframework.boot:spring-boot-autoconfigure'
     implementation 'org.springframework.boot:spring-boot-starter-logging'

--- a/examples/functional-tests/grails-app/conf/application.yml
+++ b/examples/functional-tests/grails-app/conf/application.yml
@@ -70,7 +70,7 @@ hibernate:
         queries: false
         use_second_level_cache: false
         use_query_cache: false
-        #region.factory_class: 'org.hibernate.cache.ehcache.EhCacheRegionFactory'
+        region.factory_class: 'org.hibernate.cache.ehcache.EhCacheRegionFactory'
         
 endpoints:
     jmx:

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,6 +6,8 @@ grailsGradlePluginVersion=7.0.0-SNAPSHOT
 grailsVersion=7.0.0-SNAPSHOT
 asciidoctorVersion=4.0.3
 micronautVersion=4.6.5
+hibernateVersion=5.6.15.Final
+jbossTransactionApiVersion=2.0.0.Final
 
 # This prevents the Grails Gradle Plugin from unnecessarily excluding slf4j-simple in the generated POMs
 # https://github.com/grails/grails-gradle-plugin/issues/222


### PR DESCRIPTION
While excluding hibernate-core (javax) and including jboss-transaction-api