### PR TITLE
Fix fallout from deletion of deprecated classes:

### DIFF
--- a/fields/plugin/build.gradle
+++ b/fields/plugin/build.gradle
@@ -31,7 +31,7 @@ dependencies {
     testImplementation "org.apache.groovy:groovy-dateutil"
     testImplementation "org.grails:grails-datastore-gorm-hibernate5"
     testImplementation "org.grails:grails-gorm-testing-support"
-    testImplementation "org.grails:grails-web-testing-support"
+    testImplementation project(':grails-web-testing-support')
     testImplementation 'org.javassist:javassist:3.29.0-GA'
     testImplementation("org.jodd:jodd-wot:$joddWotVersion") {
         exclude module: 'slf4j-api'

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@ projectVersion=7.0.0-SNAPSHOT
 githubBranch = 7.0.x
 javaVersion=17
 # when updating grails version, be sure to update the views/gradle-plugin as well
-grailsVersion=7.0.0-M3
+grailsVersion=7.0.0-SNAPSHOT
 joddWotVersion=3.3.8
 commonsTextVersion=1.13.0
 elApiVersion=6.0.1

--- a/gsp/grails-plugin-gsp/src/main/groovy/org/grails/plugins/web/GroovyPagesGrailsPlugin.groovy
+++ b/gsp/grails-plugin-gsp/src/main/groovy/org/grails/plugins/web/GroovyPagesGrailsPlugin.groovy
@@ -26,7 +26,7 @@ import grails.util.Metadata
 import grails.web.pages.GroovyPagesUriService
 import groovy.transform.CompileStatic
 import groovy.util.logging.Commons
-import org.grails.core.artefact.TagLibArtefactHandler
+import org.grails.core.artefact.gsp.TagLibArtefactHandler
 import org.grails.gsp.GroovyPageResourceLoader
 import org.grails.gsp.GroovyPagesTemplateEngine
 import org.grails.gsp.io.CachingGroovyPageStaticResourceLocator

--- a/gsp/grails-plugin-gsp/src/test/groovy/grails/gsp/PageRendererSpec.groovy
+++ b/gsp/grails-plugin-gsp/src/test/groovy/grails/gsp/PageRendererSpec.groovy
@@ -1,7 +1,7 @@
 package grails.gsp
 import grails.core.DefaultGrailsApplication
 import grails.spring.BeanBuilder
-import org.grails.core.artefact.TagLibArtefactHandler
+import org.grails.core.artefact.gsp.TagLibArtefactHandler
 import org.grails.core.io.SimpleMapResourceLoader
 import org.grails.gsp.GroovyPagesTemplateEngine
 import org.grails.plugins.web.taglib.ApplicationTagLib

--- a/gsp/grails-web-gsp-taglib/src/main/groovy/org/grails/web/pages/StandaloneTagLibraryLookup.java
+++ b/gsp/grails-web-gsp-taglib/src/main/groovy/org/grails/web/pages/StandaloneTagLibraryLookup.java
@@ -1,6 +1,6 @@
 package org.grails.web.pages;
 
-import grails.core.GrailsTagLibClass;
+import grails.core.gsp.GrailsTagLibClass;
 import grails.gsp.TagLib;
 import org.grails.core.gsp.DefaultGrailsTagLibClass;
 import org.grails.taglib.TagLibraryLookup;

--- a/gsp/grails-web-jsp/src/main/groovy/org/grails/web/taglib/jsp/JspInvokeGrailsTagLibTag.java
+++ b/gsp/grails-web-jsp/src/main/groovy/org/grails/web/taglib/jsp/JspInvokeGrailsTagLibTag.java
@@ -39,7 +39,7 @@ import jakarta.servlet.jsp.tagext.BodyTagSupport;
 import jakarta.servlet.jsp.tagext.DynamicAttributes;
 
 import grails.core.GrailsApplication;
-import org.grails.core.artefact.TagLibArtefactHandler;
+import org.grails.core.artefact.gsp.TagLibArtefactHandler;
 import org.grails.buffer.FastStringPrintWriter;
 import org.grails.gsp.GroovyPage;
 import org.grails.taglib.GrailsTagException;

--- a/gsp/grails-web-testing-support/src/main/groovy/org/grails/testing/runtime/support/LazyTagLibraryLookup.java
+++ b/gsp/grails-web-testing-support/src/main/groovy/org/grails/testing/runtime/support/LazyTagLibraryLookup.java
@@ -19,7 +19,7 @@
 
 package org.grails.testing.runtime.support;
 
-import grails.core.GrailsTagLibClass;
+import grails.core.gsp.GrailsTagLibClass;
 import groovy.lang.GroovyObject;
 import org.grails.plugins.web.GroovyPagesGrailsPlugin;
 import org.grails.taglib.TagLibraryLookup;
@@ -54,10 +54,6 @@ public class LazyTagLibraryLookup extends TagLibraryLookup {
         try {
             defaultTagLibClass = Class.forName("org.grails.core.gsp.DefaultGrailsTagLibClass");
         } catch (ClassNotFoundException e) {
-            try {
-                defaultTagLibClass = Class.forName("org.grails.core.DefaultGrailsTagLibClass");
-            } catch (ClassNotFoundException f) {
-            }
         }
 
         try {
@@ -100,7 +96,7 @@ public class LazyTagLibraryLookup extends TagLibraryLookup {
     }
 
     @Override
-    protected void putTagLib(Map<String, Object> tags, String name, grails.core.GrailsTagLibClass taglib) {
+    protected void putTagLib(Map<String, Object> tags, String name, GrailsTagLibClass taglib) {
         if (applicationContext.containsBean(taglib.getFullName())) {
             super.putTagLib(tags, name, taglib);
         }

--- a/views/gradle-plugin/gradle.properties
+++ b/views/gradle-plugin/gradle.properties
@@ -1,4 +1,4 @@
-grailsVersion=7.0.0-M3
+grailsVersion=7.0.0-SNAPSHOT
 javaVersion=17
 
 org.gradle.caching=false


### PR DESCRIPTION
grails.core.GrailsTagLibClass
org.grails.core.artefact.TagLibArtefactHandler
org.grails.core.DefaultGrailsTagLibClass