### PR TITLE
ci: test fix for `groovy-joint-workflow`

### DIFF
--- a/.github/workflows/groovy-joint-workflow.yml
+++ b/.github/workflows/groovy-joint-workflow.yml
@@ -91,10 +91,6 @@ jobs:
       - name: "🐘 Configure Gradle Plugins (step 3/3)"
         run: |
           cd groovy
-          # Delete existing plugins from settings.gradle file
-          sed -i '32,37d' settings.gradle
-          # Add Develocity setup related configuration after line no 31 in settings.gradle
-          echo "${{ steps.develocity-conf-1.outputs.value }}" | sed -i -e "31r /dev/stdin" settings.gradle
           # Delete existing buildCache configuration from gradle/build-scans.gradle file
           sed -i '23,46d' gradle/build-scans.gradle
           # Add Develocity setup related configuration after line no 22 in gradle/build-scans.gradle


### PR DESCRIPTION
After upgrade to `develocity` plugin 4.0 it seems
the Groovy build is no longer working:
Failed to apply plugin 'me.champeau.buildscan-recipes'

This commit tests to not use the develocity plugin version defined in this project for the Groovy build.